### PR TITLE
Improve config handling and exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+<!-- Instructions for testing and formatting code -->
+
+After making the desired changes to the code, run `npm run validate` to check
+for errors. Fix the errors and rerun `npm run validate` until there are no
+errors. After `npm run validate` returns no errors, run `npm run format` to
+format the code.

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -42,8 +42,8 @@ const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>()
  * 2. Shows an approval dialog if not approved
  */
 app.get('/authorize', async (c) => {
-        try {
-                const config = getConfig()
+	try {
+		const config = getConfig()
 		const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
 		const { clientId } = oauthReqInfo
 
@@ -92,8 +92,8 @@ app.get('/authorize', async (c) => {
  * and redirects to Schwab for authentication
  */
 app.post('/authorize', async (c) => {
-        try {
-                const config = getConfig()
+	try {
+		const config = getConfig()
 		const { state, headers } = await parseRedirectApproval(c.req.raw, config)
 
 		if (!state.oauthReqInfo) {
@@ -143,8 +143,8 @@ app.post('/authorize', async (c) => {
  * authorization flow.
  */
 app.get('/callback', async (c) => {
-        try {
-                const config = getConfig()
+	try {
+		const config = getConfig()
 		// Extract state and code from query parameters
 		const stateParam = c.req.query('state')
 		const code = c.req.query('code')

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -7,7 +7,7 @@ import {
 } from '@sudowealth/schwab-api'
 import { Hono } from 'hono'
 import { type Env } from '../../types/env'
-import { buildConfig } from '../config'
+import { getConfig } from '../config'
 import { logger } from '../shared/logger'
 import { initializeSchwabAuthClient, redirectToSchwab } from './client'
 import { clientIdAlreadyApproved, parseRedirectApproval } from './cookies'
@@ -42,8 +42,8 @@ const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>()
  * 2. Shows an approval dialog if not approved
  */
 app.get('/authorize', async (c) => {
-	try {
-		const config = buildConfig(c.env)
+        try {
+                const config = getConfig()
 		const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
 		const { clientId } = oauthReqInfo
 
@@ -92,8 +92,8 @@ app.get('/authorize', async (c) => {
  * and redirects to Schwab for authentication
  */
 app.post('/authorize', async (c) => {
-	try {
-		const config = buildConfig(c.env)
+        try {
+                const config = getConfig()
 		const { state, headers } = await parseRedirectApproval(c.req.raw, config)
 
 		if (!state.oauthReqInfo) {
@@ -143,8 +143,8 @@ app.post('/authorize', async (c) => {
  * authorization flow.
  */
 app.get('/callback', async (c) => {
-	try {
-		const config = buildConfig(c.env)
+        try {
+                const config = getConfig()
 		// Extract state and code from query parameters
 		const stateParam = c.req.query('state')
 		const code = c.req.query('code')

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,20 +8,20 @@ let cachedConfig: ValidatedEnv | undefined
  * Should be called from the Worker `setup()` phase.
  */
 export function initConfig(env: Env): ValidatedEnv {
-        if (!cachedConfig) {
-                cachedConfig = buildConfig(env)
-        }
-        return cachedConfig
+	if (!cachedConfig) {
+		cachedConfig = buildConfig(env)
+	}
+	return cachedConfig
 }
 
 /**
  * Retrieve the previously initialised configuration.
  */
 export function getConfig(): ValidatedEnv {
-        if (!cachedConfig) {
-                throw new Error('Config has not been initialised')
-        }
-        return cachedConfig
+	if (!cachedConfig) {
+		throw new Error('Config has not been initialised')
+	}
+	return cachedConfig
 }
 
 export { buildConfig }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,27 @@
-// Export all functionality from the AppConfig module
-export { buildConfig } from './appConfig'
+import type { Env, ValidatedEnv } from '../../types/env'
+import { buildConfig } from './appConfig'
+
+let cachedConfig: ValidatedEnv | undefined
+
+/**
+ * Initialize and cache the application configuration.
+ * Should be called from the Worker `setup()` phase.
+ */
+export function initConfig(env: Env): ValidatedEnv {
+        if (!cachedConfig) {
+                cachedConfig = buildConfig(env)
+        }
+        return cachedConfig
+}
+
+/**
+ * Retrieve the previously initialised configuration.
+ */
+export function getConfig(): ValidatedEnv {
+        if (!cachedConfig) {
+                throw new Error('Config has not been initialised')
+        }
+        return cachedConfig
+}
+
+export { buildConfig }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,10 +27,10 @@ export class MyMCP extends DurableMCP<MyMCPProps, Env> {
 	})
 
 	async init() {
-                try {
-                        logger.info('[MyMCP.init] STEP 0: Start')
-                        this.validatedConfig = getConfig()
-                        const redirectUri = this.validatedConfig.SCHWAB_REDIRECT_URI
+		try {
+			logger.info('[MyMCP.init] STEP 0: Start')
+			this.validatedConfig = getConfig()
+			const redirectUri = this.validatedConfig.SCHWAB_REDIRECT_URI
 			logger.info('[MyMCP.init] STEP 1: Env initialized.')
 
 			// Use schwab-api's TokenSet for the function signatures
@@ -244,8 +244,8 @@ export class MyMCP extends DurableMCP<MyMCPProps, Env> {
 				? this.tokenManager.constructor.name
 				: 'undefined',
 		}
-                try {
-                        const env = this.validatedConfig ?? getConfig()
+		try {
+			const env = this.validatedConfig ?? getConfig()
 			diagnosticInfo.environment = {
 				hasClientId: !!env.SCHWAB_CLIENT_ID,
 				hasClientSecret: !!env.SCHWAB_CLIENT_SECRET,
@@ -303,20 +303,20 @@ export class MyMCP extends DurableMCP<MyMCPProps, Env> {
 }
 
 const provider = new OAuthProvider({
-        apiRoute: '/sse',
-        apiHandler: MyMCP.mount('/sse') as any, // Cast remains due to library typing
-        defaultHandler: SchwabHandler as any, // Cast remains
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/token',
-        clientRegistrationEndpoint: '/register',
+	apiRoute: '/sse',
+	apiHandler: MyMCP.mount('/sse') as any, // Cast remains due to library typing
+	defaultHandler: SchwabHandler as any, // Cast remains
+	authorizeEndpoint: '/authorize',
+	tokenEndpoint: '/token',
+	clientRegistrationEndpoint: '/register',
 })
 
 export default {
-        setup(env: Env) {
-                const config = initConfig(env)
-                makeLogger(config.LOG_LEVEL ?? 'INFO')
-        },
-        fetch(request: Request, env: Env, ctx: ExecutionContext) {
-                return provider.fetch(request, env, ctx)
-        },
+	setup(env: Env) {
+		const config = initConfig(env)
+		makeLogger(config.LOG_LEVEL ?? 'INFO')
+	},
+	fetch(request: Request, env: Env, ctx: ExecutionContext) {
+		return provider.fetch(request, env, ctx)
+	},
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,3 @@
-// Market tools
-export * from './market'
-
-// Trader tools
-export * from './trader'
+// Re-export stable tool registration functions only
+export { registerMarketTools } from './market'
+export { registerTraderTools } from './trader'


### PR DESCRIPTION
## Summary
- create a cached config API and initialize it in worker setup
- use cached config from auth handler and MCP class
- expose only stable tool registration functions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run validate`
